### PR TITLE
Display users Email + Bugfix

### DIFF
--- a/resources/js/Components/Header.vue
+++ b/resources/js/Components/Header.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { AuthTypes } from "@/types";
 import { onMounted, onUnmounted, ref } from "vue";
+
+const { auth } = defineProps<AuthTypes>();
+
+console.log(auth.user);
 
 const hideThreshold = 120;
 
@@ -46,11 +51,20 @@ const header_height = "h-[55px] md:h-[65px]";
         ]"
     >
         <div class="flex gap-6 items-center justify-between">
-            <div
+            <a
+                v-if="auth.user"
+                href="/dashboard"
                 class="px-3 py-1 border-[1px] border-gray-500 dark:border-dark rounded-lg"
             >
-                Profile
-            </div>
+                {{ auth.user.email }}
+            </a>
+            <a
+                v-else
+                href="/login"
+                class="px-3 py-1 border-[1px] border-gray-500 dark:border-dark rounded-lg"
+            >
+                Login
+            </a>
 
             <!-- cart svg -->
             <svg

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -4,14 +4,15 @@ import Header from "@/Components/Header.vue";
 import Footer from "@/Components/Footer.vue";
 import { Head } from "@inertiajs/vue3";
 import { ProductsType } from "@/types/Products";
+import { AuthTypes } from "@/types";
 
-const { products } = defineProps<ProductsType>();
+const { products, auth } = defineProps<ProductsType & AuthTypes>();
 </script>
 
 <template>
     <Head title="Welcome" />
 
-    <Header />
+    <Header :auth="auth" />
     <section
         class="container mx-auto px-8 mt-4 md:mt-8 flex flex-col items-center justify-start pb-12"
     >

--- a/resources/js/types/Products.ts
+++ b/resources/js/types/Products.ts
@@ -1,9 +1,11 @@
 interface Product {
+    id: number;
     title: string;
     caption: string;
     image: string;
     image_thumbnail: string;
     price: string;
+    stock: number;
     status: 0 | 1;
 }
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Config } from 'ziggy-js';
+import { Config } from "ziggy-js";
 
 export interface User {
     id: number;
@@ -7,9 +7,17 @@ export interface User {
     email_verified_at: string;
 }
 
-export type PageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {
+export type PageProps<
+    T extends Record<string, unknown> = Record<string, unknown>
+> = T & {
     auth: {
         user: User;
     };
     ziggy: Config & { location: string };
+};
+
+export type AuthTypes = {
+    auth: {
+        user: User;
+    };
 };


### PR DESCRIPTION
Add - the header now displays a Login button on the right side and directs the user to the login page. if the user is logged in display their email address instead which on click navigates the user to their dashboard (/dashboard)

Fix - add the **Id** and **Stock** fields in ProductType

